### PR TITLE
Removed duplicate social media tiles

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -44,7 +44,7 @@
     </div>
     <footer>
       <span i18n>
-        &copy; {{currentYear()}} <b>DD-IX</b> <span class="slogan">- Keep Local Traffic Local.</span>
+        &copy; {{currentYear()}} <b>DD-IX</b> <span class="slogan"> | Keep Local Traffic Local</span>
       </span>
       <nav>
         <a routerLink="/privacy-policy" i18n>Privacy Policy</a>

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -29,29 +29,11 @@
     </a>
   </li>
   <li>
-    <a href="https://c3d2.social/dd-ix" target="_blank">
+    <a href="https://dresden.network/@dd-ix" target="_blank">
       <section>
         <app-icon-mastodon class="icon"></app-icon-mastodon>
         <h1>Mastodon</h1>
-        <p><b>@dd-ix@c3d2.social</b></p>
-      </section>
-    </a>
-  </li>
-  <li>
-    <a href="https://github.com/dd-ix" target="_blank">
-      <section>
-        <app-icon-github class="icon"></app-icon-github>
-        <h1>GitHub</h1>
-        <p><b>@dd-ix</b></p>
-      </section>
-    </a>
-  </li>
-  <li>
-    <a href="https://c3d2.social/dd-ix" target="_blank">
-      <section>
-        <app-icon-mastodon class="icon"></app-icon-mastodon>
-        <h1>Mastodon</h1>
-        <p><b>@dd-ix@c3d2.social</b></p>
+        <p><b>@dd-ix@dresden.network</b></p>
       </section>
     </a>
   </li>


### PR DESCRIPTION
social: remove duplicate social tiles
    
- remove them for now as it looks unfinished
- updating the mastodon link to the pending proposal by @Vespertil